### PR TITLE
Adding Volumetric Clouds support.

### DIFF
--- a/OPX-SarnusPlus/Patches/Scatterer/Sarnus-Settings.cfg
+++ b/OPX-SarnusPlus/Patches/Scatterer/Sarnus-Settings.cfg
@@ -1,4 +1,4 @@
-@Scatterer_atmosphere:AFTER[OPX-SarnusPlus]
+@Scatterer_atmosphere:NEEDS[!OPMVolumetricClouds]:AFTER[OPX-SarnusPlus]
 {
 	Atmo
 	{

--- a/OPX-SarnusPlus/Patches/Scatterer/Tekto-Settings.cfg
+++ b/OPX-SarnusPlus/Patches/Scatterer/Tekto-Settings.cfg
@@ -1,4 +1,4 @@
-@Scatterer_atmosphere:AFTER[OPX-SarnusPlus]
+@Scatterer_atmosphere:NEEDS[!OPMVolumetricClouds]:AFTER[OPX-SarnusPlus]
 {
 	Atmo
 	{
@@ -60,7 +60,7 @@
 		}
 	}
 }
-@Scatterer_ocean:AFTER[OPX-SarnusPlus]
+@Scatterer_ocean:NEEDS[!OPMVolumetricClouds]:AFTER[OPX-SarnusPlus]
 {
 	Ocean
 	{


### PR DESCRIPTION
OPMVolumetricClouds has the configs for all the atmospheric bodies in OPX, but OPX stomps on top of them. This PR just stops these patches from running when OPMVolumetricClouds exists.