### PR TITLE
Updates texture references to eliminate Kopernicus error messages

### DIFF
--- a/OPX-SarnusPlus/KopernicusConfigs/03-Hale.cfg
+++ b/OPX-SarnusPlus/KopernicusConfigs/03-Hale.cfg
@@ -155,7 +155,7 @@
 				midBumpMapOffset = 0,0
 				midBumpTiling = 70000
 				
-				highTex = OPX-SarnusPlus/Textures/PluginData.snow.dds
+				highTex = OPX-SarnusPlus/Textures/PluginData/snow.dds
 				highTexScale = 1,1
 				highTexOffset = 0,0
 				highTiling = 70000

--- a/OPX-SarnusPlus/KopernicusConfigs/11-Phabus.cfg
+++ b/OPX-SarnusPlus/KopernicusConfigs/11-Phabus.cfg
@@ -275,10 +275,10 @@
 							Material
 							{
 								color = 0.33,0.28,0.21,1
-								mainTex = OPX-SarnusPlus/Textures/PluginData/rock
+								mainTex = OPX-SarnusPlus/Textures/PluginData/rock.dds
 								mainTexScale = 1,1
 								mainTexOffset = 0,0
-								bumpMap = OPX-SarnusPlus/Textures/PluginData/rock_normal
+								bumpMap = OPX-SarnusPlus/Textures/PluginData/rock_normal.dds
 								bumpMapScale = 1,1
 								bumpMapOffset = 0,0
 							}


### PR DESCRIPTION
References for rock and rock_normal were missing the .dds extension, and snow had typo "." instead of "/" causing path error.